### PR TITLE
add ignore_long_title function

### DIFF
--- a/R/grattan_save.R
+++ b/R/grattan_save.R
@@ -69,6 +69,8 @@
 #' @param latex Logical. FALSE by default. If TRUE, exports figure environment
 #' LaTeX code to clipboard and console.
 #' @param dpi Plot resolution. Default is "retina".
+#' @param ignore_long_title Default is FALSE. If TRUE, the check on a long title
+#' won't be performed. This is useful if using ggtext syntax within titles.
 #' @param ... arguments passed to `ggsave()`. For example, use
 #' `device = cairo_pdf` to use the Cairo PDF rendering engine.
 #' For `grattan_save_all()`, the `...` are passed to `grattan_save()`.
@@ -147,6 +149,7 @@ grattan_save <- function(filename,
                          watermark = NULL,
                          latex = FALSE,
                          dpi = "retina",
+                         ignore_long_title = FALSE,
                          ...) {
 
   if (!type %in% c("all", all_chart_types)) {
@@ -201,6 +204,7 @@ grattan_save <- function(filename,
                   force_labs = force_labs,
                   dpi = dpi,
                   save_pptx = save_pptx,
+                  ignore_long_title = ignore_long_title,
                   ...)
   }
 
@@ -248,6 +252,7 @@ grattan_save <- function(filename,
                  force_labs = force_labs,
                  dpi = dpi,
                  save_pptx = save_pptx,
+                 ignore_long_title = ignore_long_title,
                  ...)
 
   }
@@ -267,6 +272,7 @@ grattan_save_ <- function(filename,
                           force_labs,
                           dpi,
                           save_pptx,
+                          ignore_long_title,
                           ...) {
 
   plot_class <- chart_types$class[chart_types$type == type]
@@ -275,7 +281,7 @@ grattan_save_ <- function(filename,
   # logo
   if (plot_class == "fullslide") {
 
-    object <- wrap_labs(object, type)
+    object <- wrap_labs(object, type, ignore_long_title = ignore_long_title)
 
     object <- create_fullslide(plot = object,
                                type = type)

--- a/R/wrap_labs.R
+++ b/R/wrap_labs.R
@@ -15,6 +15,8 @@
 #'   \code{?grattan_save()}.
 #' @param labs_to_wrap Default is c("title", "subtitle", "caption"), which
 #' wraps all three labels. Choose one or two if you only want to wrap those.
+#' @param ignore_long_title Default is FALSE. If TRUE, the check on a long title
+#' won't be performed. This is useful if using ggtext syntax within titles.
 #'
 #' @examples
 #'
@@ -36,7 +38,8 @@
 
 wrap_labs <- function(object,
                       type,
-                      labs_to_wrap = c("title", "subtitle", "caption")) {
+                      labs_to_wrap = c("title", "subtitle", "caption"),
+                      ignore_long_title = FALSE) {
 
   p <- object
 
@@ -66,7 +69,8 @@ wrap_labs <- function(object,
         stored_title <- paste0("\n", stored_title)
       }
 
-      if (nchar(stored_title) > 2 * char_width_grattan_title) {
+
+      if (!ignore_long_title & (nchar(stored_title) > 2 * char_width_grattan_title)) {
         # if title > 2 lines, return an informative error that tells users
         # where they need to trim their title to
 
@@ -83,7 +87,8 @@ wrap_labs <- function(object,
       }
 
       if (nchar(stored_title) <= 2 * char_width_grattan_title &
-          nchar(stored_title) > char_width_grattan_title) {
+          nchar(stored_title) > char_width_grattan_title &
+          !ignore_long_title) {
 
         stored_title <- paste0(strwrap(stored_title, char_width_grattan_title)[1],
                                "\n",
@@ -103,7 +108,7 @@ wrap_labs <- function(object,
 
       char_width_grattan_subtitle <- chart_types$subtitle[chart_types$type == type]
 
-      if (nchar(stored_subtitle) > 2 * char_width_grattan_subtitle) {
+      if (nchar(stored_subtitle) > 2 * char_width_grattan_subtitle & !ignore_long_title) {
         # code to figure out the final 2 chunks of text before the title limit
         trimmed_subtitle <- strtrim(stored_subtitle, 2 * char_width_grattan_subtitle)
         trimmed_subtitle_final_words <- paste0(utils::tail(strsplit(trimmed_subtitle, split = " ")[[1]],2), collapse = " ")
@@ -118,7 +123,8 @@ wrap_labs <- function(object,
       }
 
       if (nchar(stored_subtitle) <= 2 * char_width_grattan_subtitle &
-          nchar(stored_subtitle) > char_width_grattan_subtitle) {
+          nchar(stored_subtitle) > char_width_grattan_subtitle &
+          !ignore_long_title) {
 
         stored_subtitle <- paste0(strwrap(stored_subtitle, char_width_grattan_subtitle)[1],
                                   "\n",

--- a/man/grattan_save.Rd
+++ b/man/grattan_save.Rd
@@ -16,6 +16,7 @@ grattan_save(
   watermark = NULL,
   latex = FALSE,
   dpi = "retina",
+  ignore_long_title = FALSE,
   ...
 )
 
@@ -94,6 +95,9 @@ before saving your plot.}
 LaTeX code to clipboard and console.}
 
 \item{dpi}{Plot resolution. Default is "retina".}
+
+\item{ignore_long_title}{Default is FALSE. If TRUE, the check on a long title
+won't be performed. This is useful if using ggtext syntax within titles.}
 
 \item{...}{arguments passed to `ggsave()`. For example, use
 `device = cairo_pdf` to use the Cairo PDF rendering engine.

--- a/man/wrap_labs.Rd
+++ b/man/wrap_labs.Rd
@@ -4,7 +4,12 @@
 \alias{wrap_labs}
 \title{Format title, subtitle, and caption of a ggplot2 chart in the Grattan style.}
 \usage{
-wrap_labs(object, type, labs_to_wrap = c("title", "subtitle", "caption"))
+wrap_labs(
+  object,
+  type,
+  labs_to_wrap = c("title", "subtitle", "caption"),
+  ignore_long_title = FALSE
+)
 }
 \arguments{
 \item{object}{Name of the ggplot2 chart object with the labels you wish to
@@ -17,6 +22,9 @@ different numbers of characters on each line). `type` can be 'normal',
 
 \item{labs_to_wrap}{Default is c("title", "subtitle", "caption"), which
 wraps all three labels. Choose one or two if you only want to wrap those.}
+
+\item{ignore_long_title}{Default is FALSE. If TRUE, the check on a long title
+won't be performed. This is useful if using ggtext syntax within titles.}
 }
 \description{
 Use `wrap_labs()` to wrap the title, subtitle, and caption of a ggplot2 chart

--- a/tests/testthat/test-grattan_save.R
+++ b/tests/testthat/test-grattan_save.R
@@ -17,6 +17,17 @@ test_plot_nolabs <- ggplot(mtcars, aes(x = wt, y = mpg, col = factor(cyl))) +
   grattan_colour_manual(n = 3) +
   grattan_y_continuous(limits = c(0, 40))
 
+test_plot_longlabs <- ggplot(mtcars, aes(x = wt, y = mpg, col = factor(cyl))) +
+  geom_point() +
+  theme_grattan() +
+  grattan_colour_manual(n = 3) +
+  grattan_y_continuous(limits = c(0, 40)) +
+  labs(x = "Weight",
+       title = "Smaller cars get better mileage Smaller cars get better mileage Smaller cars get better mileage Smaller cars get better mileage Smaller cars get better mileage Smaller cars get better mileage Smaller cars get better mileage",
+       subtitle = "Smaller cars get better mileage Smaller cars get better mileage Smaller cars get better mileage Smaller cars get better mileage Smaller cars get better mileage Smaller cars get better mileage Smaller cars get better mileage",
+       caption = "Source: mtcars dataset")
+
+
 test_that("grattan_save() saves charts (no powerpoint)", {
 
   grattan_save(filename = "../figs/grattan_save/test_plot.png",
@@ -226,4 +237,19 @@ test_that("grattan_save_all() works", {
 
   unlink("../figs/grattan_save_all", recursive = TRUE)
   unlink("../testthat/Rplots.pdf")
+})
+
+
+test_that("grattan_save(ignore_long_titles = TRUE) successfully ignores long titles", {
+
+  expect_error(
+    grattan_save(filename = "test_plot_fullslide_default_height.png",
+               object = test_plot_longlabs,
+               type = "fullslide")
+  )
+
+  grattan_save(filename = "test_plot_fullslide_default_height.png",
+               object = test_plot_longlabs,
+               type = "fullslide",
+               ignore_long_title = TRUE)
 })

--- a/tests/testthat/test-wrap_labs.R
+++ b/tests/testthat/test-wrap_labs.R
@@ -16,6 +16,22 @@ test_that("long title fails", {
 
 })
 
+test_that("long title doesn't fail when ignored", {
+  p <-  base_plot +
+    labs(title = "This is a really long title that should fail wrap_labs with an error because it flows onto more than two lines, so it should definitely fail blah blah blah")
+
+  expect_type(wrap_labs(p, type = "fullslide", ignore_long_title = TRUE), "list")
+
+
+  p <- base_plot +
+    labs(title = "Regular title",
+         subtitle = "Extremely long subtitle that should fail wrap_labs with an error, it'll take up too many lines even for a monster chart etc etc etc etc lorem ipsum lorem ipsum")
+
+  expect_type(wrap_labs(p, type = "fullslide", ignore_long_title = TRUE), "list")
+
+})
+
+
 
 test_that("two line title wraps", {
 


### PR DESCRIPTION
Adds `ignore_long_title = FALSE` argument to `grattan_save` (via `wrap_labels()`). Adds tests .